### PR TITLE
Use pnpm managed `node_modules` where possible

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# Use `sh reveal-node-modules.sh`
-enable-modules-dir=false

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,7 +31,6 @@ npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm")
 npm.npm_translate_lock(
     name = "npm",
     pnpm_lock = "//:pnpm-lock.yaml",
-    npmrc = "//:.npmrc",
 )
 use_repo(npm, "npm")
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -18,5 +18,8 @@
         "@types/node": "catalog:vscode",
         "@types/vscode": "^1.100.0",
         "ava": "catalog:"
+    },
+    "scripts": {
+        "prepare": "sh ../packages/bazelify-node-modules.sh"
     }
 }

--- a/packages/bazelify-node-modules.sh
+++ b/packages/bazelify-node-modules.sh
@@ -1,0 +1,13 @@
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+PACKAGE="$(git rev-parse --show-prefix)"
+PACKAGE="${PACKAGE%/}"
+BAZEL_BIN="$(bazel --quiet info bazel-bin)"
+
+echo "Building //$PACKAGE:node_modules"
+bazel --quiet build --show_result=0 :node_modules
+
+echo "Deleting ./node_modules"
+rm -rf ./node_modules
+
+echo "Linking"
+ln --symbolic --no-dereference "$BAZEL_BIN/$PACKAGE/node_modules" ./node_modules

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+  injectWorkspacePackages: true
 
 catalogs:
   default:


### PR DESCRIPTION
Goal was to have Bazel-built packages injected via hooks, unfortunately pnpm special cases workspace packages to much (`fetchers.directory` is invoked when injected workspace packages setting is enabled, however it seems to be ignored and errors raised do nothing).

This PR strikes a balance. pnpm gets to control most `node_modules` directories (fixing workflows like patching) and workspace packages that depend on other workspace packages get a Bazel-managed `node_modules` added via `prepare` hook.

Closes #125