### PR TITLE
Ship ESM

### DIFF
--- a/build_defs/rollup_bundle/src/main.ts
+++ b/build_defs/rollup_bundle/src/main.ts
@@ -72,7 +72,7 @@ try {
         entryFileNames: (chunkInfo) => {
             return chunkInfo.name.replace("dist/", "") + ".js";
         },
-        format: "cjs",
+        format: "esm",
         generatedCode: "es2015",
         // Bazel wants all outputs to be pre-declared, to satisfy this all chunks are put
         // into a single directory that maps to a directory output.

--- a/extension/vsix/package.json
+++ b/extension/vsix/package.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "version": "0.1.22",
     "engines": {
-        "vscode": "^1.90.1"
+        "vscode": "^1.101.0"
     },
     "extensionKind": [
         "workspace"
@@ -18,6 +18,7 @@
     "activationEvents": [
         "onStartupFinished"
     ],
+    "type": "module",
     "main": "./src/main.js",
     "icon": "resources/icons/git.png",
     "capabilities": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ catalogs:
       version: 9.0.1
   vscode:
     '@types/node':
-      specifier: ^20.19.1
-      version: 20.19.1
+      specifier: ^22.15.32
+      version: 22.15.32
 
 overrides:
   minimist@<1.2.6: ^1.2.8
@@ -127,7 +127,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: catalog:vscode
-        version: 20.19.1
+        version: 22.15.32
       '@types/vscode':
         specifier: ^1.101.0
         version: 1.101.0
@@ -145,7 +145,7 @@ importers:
         version: 0.5.1
       '@types/node':
         specifier: catalog:vscode
-        version: 20.19.1
+        version: 22.15.32
       compare-versions:
         specifier: ^6.1.1
         version: 6.1.1
@@ -600,8 +600,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@20.19.1':
-    resolution: {integrity: sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==}
+  '@types/node@22.15.32':
+    resolution: {integrity: sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==}
 
   '@types/node@24.0.3':
     resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
@@ -2934,7 +2934,7 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@20.19.1':
+  '@types/node@22.15.32':
     dependencies:
       undici-types: 6.21.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,4 +13,4 @@ catalog:
 
 catalogs:
   vscode:
-    '@types/node': ^20.19.1
+    '@types/node': ^22.15.32


### PR DESCRIPTION
Relies on https://github.com/microsoft/vscode/commit/ea0483469b9f86986f35af2d436af65f37d969b9, which is set to go out with v1.101.0 (May 2025 iteration of VSCode).