### PR TITLE
Fix renovate integration for `install.sh`

### DIFF
--- a/.devcontainer/feature-bazel/install.sh
+++ b/.devcontainer/feature-bazel/install.sh
@@ -8,29 +8,29 @@ echo "Running install..."
 ARCH="$(uname --processor)"
 
 # renovate: datasource=github-tags depName=bazelbuild/bazelisk
-BAZELISK_VERSION="1.26.0"
+BAZELISK_VERSION="v1.26.0"
 # renovate: datasource=github-tags depName=bazelbuild/buildtools
-BUILDTOOLS_VERSION="8.2.1"
+BUILDTOOLS_VERSION="v8.2.1"
 # renovate: datasource=github-tags depName=withered-magic/starpls
-STARPLS_VERSION="0.1.21"
+STARPLS_VERSION="v0.1.21"
 # renovate: datasource=github-tags depName=pnpm/pnpm
-PNPM_VERSION="10.12.4"
+PNPM_VERSION="v10.12.4"
 
 if [[ $ARCH == "arm64" ]] || [[ $ARCH == "aarch64" ]]; then
-    curl "https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VERSION}/bazelisk-linux-arm64" -Lo /usr/local/bin/bazel
-    curl "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/buildifier-linux-arm64" -Lo /usr/local/bin/buildifier
-    curl "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/buildozer-linux-arm64" -Lo /usr/local/bin/buildozer
-    curl "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/unused_deps-linux-arm64" -Lo /usr/local/bin/unused_deps
-    curl "https://github.com/withered-magic/starpls/releases/download/v${STARPLS_VERSION}/starpls-linux-aarch64" -Lo /usr/local/bin/starpls
-    curl "https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}/pnpm-linux-arm64" -Lo /usr/local/bin/pnpm
+    curl "https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-arm64" -Lo /usr/local/bin/bazel
+    curl "https://github.com/bazelbuild/buildtools/releases/download/${BUILDTOOLS_VERSION}/buildifier-linux-arm64" -Lo /usr/local/bin/buildifier
+    curl "https://github.com/bazelbuild/buildtools/releases/download/${BUILDTOOLS_VERSION}/buildozer-linux-arm64" -Lo /usr/local/bin/buildozer
+    curl "https://github.com/bazelbuild/buildtools/releases/download/${BUILDTOOLS_VERSION}/unused_deps-linux-arm64" -Lo /usr/local/bin/unused_deps
+    curl "https://github.com/withered-magic/starpls/releases/download/${STARPLS_VERSION}/starpls-linux-aarch64" -Lo /usr/local/bin/starpls
+    curl "https://github.com/pnpm/pnpm/releases/download/${PNPM_VERSION}/pnpm-linux-arm64" -Lo /usr/local/bin/pnpm
 
 elif [[ $ARCH == "x86_64" ]]; then
-    curl "https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VERSION}/bazelisk-linux-amd64" -Lo /usr/local/bin/bazel
-    curl "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/buildifier-linux-amd64" -Lo /usr/local/bin/buildifier
-    curl "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/buildozer-linux-amd64" -Lo /usr/local/bin/buildozer
-    curl "https://github.com/bazelbuild/buildtools/releases/download/v${BUILDTOOLS_VERSION}/unused_deps-linux-amd64" -Lo /usr/local/bin/unused_deps
-    curl "https://github.com/withered-magic/starpls/releases/download/v${STARPLS_VERSION}/starpls-linux-amd64" -Lo /usr/local/bin/starpls
-    curl "https://github.com/pnpm/pnpm/releases/download/v${PNPM_VERSION}/pnpm-linux-x64" -Lo /usr/local/bin/pnpm
+    curl "https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64" -Lo /usr/local/bin/bazel
+    curl "https://github.com/bazelbuild/buildtools/releases/download/${BUILDTOOLS_VERSION}/buildifier-linux-amd64" -Lo /usr/local/bin/buildifier
+    curl "https://github.com/bazelbuild/buildtools/releases/download/${BUILDTOOLS_VERSION}/buildozer-linux-amd64" -Lo /usr/local/bin/buildozer
+    curl "https://github.com/bazelbuild/buildtools/releases/download/${BUILDTOOLS_VERSION}/unused_deps-linux-amd64" -Lo /usr/local/bin/unused_deps
+    curl "https://github.com/withered-magic/starpls/releases/download/${STARPLS_VERSION}/starpls-linux-amd64" -Lo /usr/local/bin/starpls
+    curl "https://github.com/pnpm/pnpm/releases/download/${PNPM_VERSION}/pnpm-linux-x64" -Lo /usr/local/bin/pnpm
 else
     echo "Unknown arch $ARCH"
     exit 1

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       "depTypeTemplate": "devcontainer.feature.bazel",
       "managerFilePatterns": [".devcontainer/feature-bazel/install.sh"],
       "matchStrings": [
-        "#\\s*renovate:\\s*(datasource=(?<datasource>.*?) )?depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*.*?_VERSION=(?<currentValue>.*)"
+        "#\\s*renovate:\\s*(datasource=(?<datasource>.*?) )?depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*.*?_VERSION=\"(?<currentValue>.*)\""
       ]
     }
   ],


### PR DESCRIPTION
Fixes 2 issues (found in #177);
1. Quotes being captured as part of the version.
2. `v` not being part of the version.