### PR TITLE
Refactor `untracked` to support large `ls-files` output

### DIFF
--- a/packages/git/BUILD.bazel
+++ b/packages/git/BUILD.bazel
@@ -1,9 +1,9 @@
+load("@aspect_rules_js//js:defs.bzl", "js_test")
 load("@aspect_rules_js//npm:defs.bzl", "npm_package")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//packages/git:ava/package_json.bzl", "bin")
 load("//build_defs/lint:linters.bzl", "eslint_test")
-load("@aspect_rules_js//js:defs.bzl", "js_test")
 
 npm_link_all_packages(name = "node_modules")
 
@@ -91,24 +91,30 @@ ts_project(
     ],
 )
 
+INTEGRATION_TESTS = [(
+    "integration_test/" + file,
+    file.replace("src/", "dist/").replace(".ts", ".js"),
+) for file in glob(["src/**/*.it.test.ts"])]
+
 test_suite(
     name = "integration_tests",
-    tests = [":integration_tests_" + str(i) for i, _ in enumerate(glob(["src/**/*.it.test.ts"]))],
+    tests = [":" + test_name for (test_name, _) in INTEGRATION_TESTS],
 )
 
 [
     js_test(
-        name = "integration_tests_" + str(i),
+        name = test_name,
+        args = [
+            "--test",
+        ],
         data = [
             "package.json",
             ":lib_integration_tests",
             "@git",
         ],
-        entry_point = s.replace("src/", "dist/").replace(".ts", ".js"),
-        args = [
-            "--test",
-        ]
-    ) for i, s in enumerate(glob(["src/**/*.it.test.ts"]))
+        entry_point = entry_point,
+    )
+    for (test_name, entry_point) in INTEGRATION_TESTS
 ]
 
 eslint_test(

--- a/packages/git/src/api/status/tracked.ts
+++ b/packages/git/src/api/status/tracked.ts
@@ -4,14 +4,14 @@ import type { GitContext } from "../../cli/context.js";
 import { err, isErr, ok, type Result, unwrap } from "../../func-result.js";
 import { createError, ERROR_GENERIC, type GenericError } from "../../errors.js";
 
-export type UntrackedErrors = GenericError;
+export type TrackedErrors = GenericError;
 
 export async function tracked(
     git: GitContext,
     cwd: string,
     pathFormat: "relative"|"absolute",
     opts?: { ignoreSubmodules?: boolean },
-): Promise<Result<IFileStatus[], UntrackedErrors>> {
+): Promise<Result<IFileStatus[], TrackedErrors>> {
     if (pathFormat === "absolute") {
         throw new Error("Not implemented");
     }

--- a/packages/git/src/api/status/untracked.it.test.ts
+++ b/packages/git/src/api/status/untracked.it.test.ts
@@ -32,3 +32,23 @@ test(untracked.name + " - relative - basic case", async () => {
     const statuses = unwrap(result);
     assert.deepStrictEqual(statuses.sort(), ["file1.txt", "file2.txt"]);
 });
+
+test(untracked.name + " - relative - many files", async () => {
+    await using repo = await tempGitRepo();
+
+    // Create many untracked files
+    const fileCount = 1000;
+    const fileNames = [];
+    for (let i = 0; i < fileCount; i++) {
+        const fileName = `file${i}.txt`;
+        fileNames.push(fileName);
+        await fs.writeFile(path.join(repo.path, fileName), `Content of ${fileName}`);
+    }
+
+    const result = await untracked(gitCtx, repo.path, "relative");
+    if (isErr(result)) {
+        throw unwrap(result);
+    }
+    const statuses = unwrap(result);
+    assert.deepStrictEqual(statuses.sort(), fileNames.sort());
+});

--- a/packages/git/src/api/status/untracked.ts
+++ b/packages/git/src/api/status/untracked.ts
@@ -1,27 +1,59 @@
+import { PassThrough } from "node:stream";
+import { finished } from "node:stream/promises";
 import type { GitContext } from "../../cli/context.js";
-import { type ReadToErrors, readToString } from "../../cli/helpers/read-to-string.js";
-import { isErr, ok, type Result, unwrap } from "../../func-result.js";
+import { err, isErr, ok, type Result, unwrap } from "../../func-result.js";
+import { createError, ERROR_GENERIC, type GenericError } from "../../errors.js";
+
+export type UntrackedErrors = GenericError;
 
 export async function untracked(
     git: GitContext,
     cwd: string,
     pathFormat: "relative"|"absolute",
-): Promise<Result<string[], ReadToErrors>> {
+): Promise<Result<string[], UntrackedErrors>> {
     if (pathFormat === "absolute") {
         throw new Error("Not implemented");
     }
 
-    // TODO Use streaming
-    const result = await readToString({ cli: git.cli, cwd }, ["ls-files", "-z", "--others", "--exclude-standard"]);
+    const parser = new GitLsFilesParser();
+    const stdout = new PassThrough();
+    stdout.on("data", (chunk: string) => {
+        parser.update(chunk);
+    });
 
-    if (isErr(result)) {
-        return result;
+    const args = ["ls-files", "-z", "--others", "--exclude-standard"];
+    const cliAction = git.cli({ cwd, stdout }, args);
+
+    const [cliResult] = await Promise.all([cliAction, finished(stdout)]);
+
+    if (isErr(cliResult)) {
+        return err(createError(ERROR_GENERIC, unwrap(cliResult)));
     }
 
-    const paths = unwrap(result)
-        .split("\0")
-        .filter(f => f !== "");
-
-    return ok(paths);
+    return ok(parser.paths);
 }
 
+class GitLsFilesParser {
+    #lastRaw = "";
+    #result: string[] = [];
+
+    get paths(): string[] {
+        return this.#result;
+    }
+
+    update(raw: string): void {
+        let normalisedRaw = raw;
+        let i = 0;
+        let nextI: number | undefined;
+
+        normalisedRaw = this.#lastRaw + normalisedRaw;
+
+        while ((nextI = normalisedRaw.indexOf("\0", i)) !== -1) {
+            const path = normalisedRaw.slice(i, nextI);
+            this.#result.push(path);
+            i = nextI + 1;
+        }
+
+        this.#lastRaw = normalisedRaw.slice(i);
+    }
+}


### PR DESCRIPTION
Fixes an issue where a large (or just modest) number of untracked files broke refreshing.