### PR TITLE
Keep `rules_rust` and `rules_rust_wasm_bindgen` versions in sync in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -88,6 +88,17 @@
       ],
       "groupName": "nodejs",
       "description": "Update NodeJS and @types/node major versions together to keep them in sync."
+    },
+    {
+      "matchManagers": [
+        "bazel"
+      ],
+      "matchDepNames": [
+        "rules_rust",
+        "rules_rust_wasm_bindgen"
+      ],
+      "groupName": "rules_rust",
+      "description": "Update rules_rust and rules_rust_wasm_bindgen together, as they need to be kept in sync."
     }
   ]
 }


### PR DESCRIPTION
Prevents issues like #675 and #676 failing to build due to breaking changes between versions.