### PR TITLE
Add Electron smoke test

### DIFF
--- a/.devcontainer/feature-bazel/install.sh
+++ b/.devcontainer/feature-bazel/install.sh
@@ -5,6 +5,27 @@ set -eax
 
 echo "Running install..."
 
+# Libraries required by Electron in //integration_tests/electron_host:electron_host_smoke_test
+apt-get update
+apt-get install -y --no-install-recommends \
+    libasound2t64 \
+    libatk1.0-0t64 \
+    libatk-bridge2.0-0t64 \
+    libatspi2.0-0t64 \
+    libcairo2 \
+    libcups2t64 \
+    libdbus-1-3 \
+    libgbm1 \
+    libglib2.0-0t64 \
+    libgtk-3-0t64 \
+    libnss3 \
+    libpango-1.0-0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2
+
 ARCH="$(uname --machine)"
 
 # renovate: datasource=github-tags depName=bazelbuild/bazelisk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           # Repo cache not worth it here, very little to fetch.
           repository-cache: false
       - run: node ./.github/workflows/update_bazel_nodejs.mjs ./.devcontainer/feature-bazel/install.sh ./MODULE.bazel
+      - run: node ./.github/workflows/update_bazel_electron.mjs
       - run: bazel mod deps --lockfile_mode=update
       - uses: stefanzweifel/git-auto-commit-action@v7
       - id: get_commit

--- a/.github/workflows/update_bazel_electron.mjs
+++ b/.github/workflows/update_bazel_electron.mjs
@@ -1,0 +1,87 @@
+import fs from "node:fs/promises";
+
+const repoRoot = new URL("../../", import.meta.url);
+const packageJsonPath = new URL("extension/vsix/package.json", repoRoot);
+const pinPath = new URL("electron-pin.json", repoRoot);
+const moduleBazelPath = new URL("MODULE.bazel", repoRoot);
+
+const pkg = JSON.parse(await fs.readFile(packageJsonPath, "utf-8"));
+const engineRange = pkg.engines?.vscode;
+const versionMatch = engineRange?.match(/\d+\.\d+\.\d+/);
+if (!versionMatch) {
+    throw new Error(`Could not parse a minimum version out of engines.vscode: "${engineRange}"`);
+}
+const vscodeVersion = versionMatch[0];
+
+const currentPin = JSON.parse(await fs.readFile(pinPath, "utf-8"));
+if (currentPin.vscodeVersion === vscodeVersion) {
+    console.log(`electron-pin.json already pinned for VS Code ${vscodeVersion}; nothing to do.`);
+    process.exit(0);
+}
+
+const vscodePackageJsonRes = await fetch(
+    `https://raw.githubusercontent.com/microsoft/vscode/${vscodeVersion}/package.json`,
+);
+if (!vscodePackageJsonRes.ok) {
+    throw new Error(`Failed to fetch VS Code ${vscodeVersion} package.json: ${vscodePackageJsonRes.status}`);
+}
+const vscodePackageJson = await vscodePackageJsonRes.json();
+const electronVersion = vscodePackageJson.devDependencies?.electron;
+if (!electronVersion) {
+    throw new Error(`microsoft/vscode@${vscodeVersion} package.json has no devDependencies.electron`);
+}
+
+const shasumsRes = await fetch(
+    `https://github.com/electron/electron/releases/download/v${electronVersion}/SHASUMS256.txt`,
+);
+if (!shasumsRes.ok) {
+    throw new Error(`Failed to fetch SHASUMS256.txt for electron v${electronVersion}: ${shasumsRes.status}`);
+}
+const shasumsText = await shasumsRes.text();
+const shaByFilename = new Map(
+    shasumsText.split("\n").filter(Boolean).map(line => {
+        const [sha, filename] = line.trim().split(/\s+/);
+        return [filename.replace(/^\*/, ""), sha];
+    }),
+);
+
+const PLATFORMS = [
+    { repoName: "electron_linux_x64", archive: "linux-x64.zip" },
+    { repoName: "electron_linux_arm64", archive: "linux-arm64.zip" },
+    { repoName: "electron_darwin_x64", archive: "darwin-x64.zip" },
+    { repoName: "electron_darwin_arm64", archive: "darwin-arm64.zip" },
+];
+
+let moduleBazelContent = await fs.readFile(moduleBazelPath, "utf-8");
+for (const { repoName, archive } of PLATFORMS) {
+    const filename = `electron-v${electronVersion}-${archive}`;
+    const sha256 = shaByFilename.get(filename);
+    if (!sha256) {
+        throw new Error(`SHASUMS256.txt for electron v${electronVersion} has no entry for ${filename}`);
+    }
+    const url = `https://github.com/electron/electron/releases/download/v${electronVersion}/${filename}`;
+
+    // buildifier alphabetises attributes (build_file_content, sha256, url), so
+    // match the whole block by name and substitute url/sha256 within it
+    // independently, rather than assuming a fixed attribute order.
+    const blockRe = new RegExp(`http_archive\\(\\s*name = "${repoName}",[\\s\\S]*?\\n\\)`);
+    const blockMatch = moduleBazelContent.match(blockRe);
+    if (!blockMatch) {
+        throw new Error(`Could not find http_archive block for ${repoName} in MODULE.bazel`);
+    }
+    const updatedBlock = blockMatch[0]
+        .replace(/url\s*=\s*"[^"]*"/, `url = "${url}"`)
+        .replace(/sha256\s*=\s*"[^"]*"/, `sha256 = "${sha256}"`);
+    moduleBazelContent = moduleBazelContent.slice(0, blockMatch.index)
+        + updatedBlock
+        + moduleBazelContent.slice(blockMatch.index + blockMatch[0].length);
+}
+await fs.writeFile(moduleBazelPath, moduleBazelContent, "utf-8");
+
+await fs.writeFile(
+    pinPath,
+    JSON.stringify({ vscodeVersion, electronVersion }, null, 4) + "\n",
+    "utf-8",
+);
+
+console.log(`Pinned Electron ${electronVersion} for VS Code ${vscodeVersion}.`);

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@aspect_rules_js//js:defs.bzl", "js_library")
 
 npm_link_all_packages(name = "node_modules")
 
@@ -12,15 +12,16 @@ ts_config(
 
 exports_files([
     "LICENSE",
-    ".shellcheckrc"
+    ".shellcheckrc",
+    "electron-pin.json",
 ])
 
 js_library(
     name = "eslintrc",
     srcs = ["eslint.config.mjs"],
+    visibility = ["//build_defs/lint:__pkg__"],
     deps = [
         ":node_modules/@eslint/js",
         ":node_modules/typescript-eslint",
     ],
-    visibility = ["//build_defs/lint:__pkg__"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -110,6 +110,56 @@ use_repo(
     "safaridriver",
 )
 
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+_ELECTRON_LINUX_BUILD_FILE = """\
+exports_files(["electron"])
+
+filegroup(
+    name = "dist",
+    srcs = glob(["**"], exclude = ["electron"]),
+    visibility = ["//visibility:public"],
+)
+"""
+
+_ELECTRON_DARWIN_BUILD_FILE = """\
+exports_files(["Electron.app/Contents/MacOS/Electron"])
+
+filegroup(
+    name = "dist",
+    srcs = glob(["**"], exclude = ["Electron.app/Contents/MacOS/Electron"]),
+    visibility = ["//visibility:public"],
+)
+"""
+
+http_archive(
+    name = "electron_linux_x64",
+    build_file_content = _ELECTRON_LINUX_BUILD_FILE,
+    sha256 = "aee1496b561509a6b7fd8ae1b2bc1bdb6f9a303966ddc7cff4989674ce8e043a",
+    url = "https://github.com/electron/electron/releases/download/v42.6.0/electron-v42.6.0-linux-x64.zip",
+)
+
+http_archive(
+    name = "electron_linux_arm64",
+    build_file_content = _ELECTRON_LINUX_BUILD_FILE,
+    sha256 = "8e3c69721cc7b009381a5be82f3fa0335d3a4420963bcd0f300c38dc072e1510",
+    url = "https://github.com/electron/electron/releases/download/v42.6.0/electron-v42.6.0-linux-arm64.zip",
+)
+
+http_archive(
+    name = "electron_darwin_x64",
+    build_file_content = _ELECTRON_DARWIN_BUILD_FILE,
+    sha256 = "2ccd775c1d6aadf50a28b97f09631061d3cfd10db50a7ee5cbe70c03b987defc",
+    url = "https://github.com/electron/electron/releases/download/v42.6.0/electron-v42.6.0-darwin-x64.zip",
+)
+
+http_archive(
+    name = "electron_darwin_arm64",
+    build_file_content = _ELECTRON_DARWIN_BUILD_FILE,
+    sha256 = "331c4b3f024e4a019861ae389654c060715218bc3ec129f72eaa02449c96f1bf",
+    url = "https://github.com/electron/electron/releases/download/v42.6.0/electron-v42.6.0-darwin-arm64.zip",
+)
+
 register_toolchains(
     # Required for building with //build_defs/platforms:vscode_ext target platform
     "//build_defs/rust_wasm_bindgen:toolchain_for_vscode_ext",

--- a/electron-pin.json
+++ b/electron-pin.json
@@ -1,0 +1,4 @@
+{
+    "vscodeVersion": "1.130.0",
+    "electronVersion": "42.6.0"
+}

--- a/extension/BUILD.bazel
+++ b/extension/BUILD.bazel
@@ -1,18 +1,25 @@
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
 load("@npm//:defs.bzl", "npm_link_all_packages")
 load("@npm//extension:ava/package_json.bzl", "bin")
-load("//build_defs/rollup_bundle:rollup_bundle.bzl", "rollup_bundle")
 load("//build_defs/lint:linters.bzl", "eslint_test")
+load("//build_defs/rollup_bundle:rollup_bundle.bzl", "rollup_bundle")
 
 npm_link_all_packages(name = "node_modules")
 
 ts_project(
     name = "lib",
-    srcs = glob(["src/**/*.ts"], exclude = ["src/**/*.test.ts", "src/**/*.stub.ts"]) + ["package.json"],
+    srcs = glob(
+        ["src/**/*.ts"],
+        exclude = [
+            "src/**/*.test.ts",
+            "src/**/*.stub.ts",
+        ],
+    ) + ["package.json"],
+    declaration = True,
     out_dir = "dist",
     root_dir = "src",
+    tsconfig = ":tsconfig",
     deps = [
-        ":node_modules/temporal-polyfill",
         ":node_modules/@types/node",
         ":node_modules/@types/vscode",
         ":node_modules/@vscode/extension-telemetry",
@@ -20,20 +27,19 @@ ts_project(
         ":node_modules/just-debounce",
         ":node_modules/monolithic-git-interop",
         ":node_modules/onetime",
+        ":node_modules/temporal-polyfill",
         ":node_modules/throat",
         ":node_modules/vscode-diff",
         ":node_modules/vscode-nls",
         ":node_modules/watcher",
     ],
-    tsconfig = ":tsconfig",
-    declaration = True,
 )
 
 ts_config(
     name = "tsconfig",
     src = "tsconfig.json",
-    deps = ["//:tsconfig"],
     visibility = [":__pkg__"],
+    deps = ["//:tsconfig"],
 )
 
 rollup_bundle(
@@ -46,31 +52,37 @@ rollup_bundle(
     external_modules = [
         "vscode",
     ],
-    visibility = ["//extension/vsix:__pkg__"],
+    visibility = [
+        "//extension/vsix:__pkg__",
+        "//integration_tests/electron_host:__pkg__",
+    ],
 )
 
 ts_project(
     name = "lib_tests",
-    srcs = glob(["src/**/*.test.ts"]) + glob(["src/**/*.stub.ts"], allow_empty = True) + ["package.json"],
+    srcs = glob(["src/**/*.test.ts"]) + glob(
+        ["src/**/*.stub.ts"],
+        allow_empty = True,
+    ) + ["package.json"],
+    declaration = True,
     out_dir = "dist",
     root_dir = "src",
+    tsconfig = ":tsconfig",
     deps = [
+        ":lib",
         ":node_modules/@types/node",
         ":node_modules/ava",
-        ":lib",
     ],
-    tsconfig = ":tsconfig",
-    declaration = True,
 )
 
 bin.ava_test(
     name = "tests",
-    data = [
-        ":lib_tests",
-        "package.json",
-    ],
-    chdir = package_name(),
     args = ["-t"],
+    chdir = package_name(),
+    data = [
+        "package.json",
+        ":lib_tests",
+    ],
 )
 
 eslint_test(

--- a/extension/vsix/BUILD.bazel
+++ b/extension/vsix/BUILD.bazel
@@ -5,6 +5,11 @@ load("@rules_shell//shell:sh_library.bzl", "sh_library")
 load("//build_defs/lint:linters.bzl", "shellcheck_test")
 load("//build_defs/vsix_package:vsix_package.bzl", "vsix_package")
 
+exports_files(
+    ["package.json"],
+    visibility = ["//integration_tests/electron_host:__pkg__"],
+)
+
 # Copy bundled sources to src/
 output_files(
     name = "bundle_chunks_ref",

--- a/integration_tests/electron_host/BUILD.bazel
+++ b/integration_tests/electron_host/BUILD.bazel
@@ -1,0 +1,120 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("//build_defs/lint:linters.bzl", "shellcheck_test")
+
+sh_library(
+    name = "run-load-check",
+    srcs = ["run-load-check.sh"],
+)
+
+selects.config_setting_group(
+    name = "linux_x86_64",
+    match_all = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+selects.config_setting_group(
+    name = "linux_arm64",
+    match_all = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+selects.config_setting_group(
+    name = "macos_x86_64",
+    match_all = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+selects.config_setting_group(
+    name = "macos_arm64",
+    match_all = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+alias(
+    name = "electron_binary",
+    actual = select({
+        ":linux_x86_64": "@electron_linux_x64//:electron",
+        ":linux_arm64": "@electron_linux_arm64//:electron",
+        ":macos_x86_64": "@electron_darwin_x64//:Electron.app/Contents/MacOS/Electron",
+        ":macos_arm64": "@electron_darwin_arm64//:Electron.app/Contents/MacOS/Electron",
+    }),
+)
+
+alias(
+    name = "electron_dist",
+    actual = select({
+        ":linux_x86_64": "@electron_linux_x64//:dist",
+        ":linux_arm64": "@electron_linux_arm64//:dist",
+        ":macos_x86_64": "@electron_darwin_x64//:dist",
+        ":macos_arm64": "@electron_darwin_arm64//:dist",
+    }),
+)
+
+BUNDLE_ENTRY_POINTS = [
+    "//extension:bundle_/main.js",
+    "//extension:bundle_/askpass-main.js",
+]
+BUNDLE_DATA = BUNDLE_ENTRY_POINTS + ["//extension:bundle"]
+
+sh_test(
+    name = "electron_host_smoke_test",
+    size = "small",
+    srcs = [":run-load-check"],
+    args = [
+        "$(rootpath :electron_binary)",
+        "$(rootpath load-check.mjs)",
+    ] + ["$(rootpath %s)" % ep for ep in BUNDLE_ENTRY_POINTS],
+    data = BUNDLE_DATA + [
+        "load-check.mjs",
+        ":electron_binary",
+        ":electron_dist",
+    ],
+    env = {"ELECTRON_RUN_AS_NODE": "1"},
+)
+
+sh_test(
+    name = "node_host_smoke_test",
+    size = "small",
+    srcs = [":run-load-check"],
+    args = [
+        "$(rootpath //build_defs/node_bin:node)",
+        "$(rootpath load-check.mjs)",
+    ] + ["$(rootpath %s)" % ep for ep in BUNDLE_ENTRY_POINTS],
+    data = BUNDLE_DATA + [
+        "load-check.mjs",
+        "//build_defs/node_bin:node",
+    ],
+)
+
+sh_test(
+    name = "electron_pin_drift_test",
+    size = "small",
+    srcs = [":run-load-check"],
+    args = [
+        "$(rootpath //build_defs/node_bin:node)",
+        "$(rootpath check-electron-pin.mjs)",
+        "$(rootpath //:electron-pin.json)",
+        "$(rootpath //extension/vsix:package.json)",
+    ],
+    data = [
+        "check-electron-pin.mjs",
+        "//:electron-pin.json",
+        "//build_defs/node_bin:node",
+        "//extension/vsix:package.json",
+    ],
+)
+
+shellcheck_test(
+    name = "shellcheck",
+    srcs = [":run-load-check"],
+)

--- a/integration_tests/electron_host/check-electron-pin.mjs
+++ b/integration_tests/electron_host/check-electron-pin.mjs
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+
+// Drift guard for `../electron-pin.json`.
+
+const [pinPath, packageJsonPath] = process.argv.slice(2);
+if (!pinPath || !packageJsonPath) {
+    console.error("usage: check-electron-pin.mjs <electron-pin.json> <package.json>");
+    process.exit(1);
+}
+
+const pin = JSON.parse(await readFile(pinPath, "utf-8"));
+const pkg = JSON.parse(await readFile(packageJsonPath, "utf-8"));
+
+const engineRange = pkg.engines?.vscode;
+if (!engineRange) {
+    console.error(`${packageJsonPath} has no engines.vscode field`);
+    process.exit(1);
+}
+
+const match = engineRange.match(/\d+\.\d+\.\d+/);
+if (!match) {
+    console.error(`Could not parse a minimum version out of engines.vscode: "${engineRange}"`);
+    process.exit(1);
+}
+const minVscodeVersion = match[0];
+
+if (pin.vscodeVersion !== minVscodeVersion) {
+    console.error(
+        `electron-pin.json is out of date: pinned for VS Code ${pin.vscodeVersion}, `
+            + `but ${packageJsonPath} requires ${engineRange} (minimum ${minVscodeVersion}).`,
+    );
+    console.error("Remediation: node ./.github/workflows/update_bazel_electron.mjs");
+    process.exit(1);
+}
+
+console.log(`OK: electron-pin.json (VS Code ${pin.vscodeVersion}, Electron ${pin.electronVersion}) is up to date.`);

--- a/integration_tests/electron_host/load-check.mjs
+++ b/integration_tests/electron_host/load-check.mjs
@@ -1,0 +1,113 @@
+import { readdir, readFile } from "node:fs/promises";
+import { registerHooks } from "node:module";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Loads each bundle entry point given on argv under the current runtime;
+// - Electron in ELECTRON_RUN_AS_NODE mode.
+// - Mainline Node.
+// A parse/instantiation failure (e.g. a host whose V8 can't parse `import source`) rejects the
+// dynamic `import()` and fails the check.
+//
+// This is necessary to prevent regressions. e.g.
+// Break: https://github.com/Silic0nS0ldier/vscode-git-monolithic-extension/commit/f4f9199053937d1a3c094f5b95f0f4346e79e3a9
+// Fix: https://github.com/Silic0nS0ldier/vscode-git-monolithic-extension/commit/ca6666135fd5c7b9b9cb4bd5cc4ad80dc52d1a56
+//
+// It's not perfect, but provides _some_ assurance that the bundle is compatible with the runtime.
+
+async function listJsFiles(dir) {
+    const out = [];
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...await listJsFiles(full));
+        else if (entry.name.endsWith(".js")) out.push(full);
+    }
+    return out;
+}
+
+const IMPORT_RE = /import\s+(?:([\w$]+)\s*,\s*)?(?:\{([^}]*)\})?\s*from\s*["']vscode["']/g;
+
+async function collectVscodeNames(bundleDir) {
+    const names = new Set();
+    for (const file of await listJsFiles(bundleDir)) {
+        const content = await readFile(file, "utf-8");
+        for (const match of content.matchAll(IMPORT_RE)) {
+            const [, defaultName, namedList] = match;
+            if (defaultName) names.add("default");
+            if (namedList) {
+                for (const part of namedList.split(",")) {
+                    const trimmed = part.trim();
+                    if (!trimmed) continue;
+                    // Strip `Foo as Bar` down to the exported name `Foo`.
+                    names.add(trimmed.split(/\s+as\s+/)[0].trim());
+                }
+            }
+        }
+    }
+    return names;
+}
+
+/**
+ * A proxy stands in for every export: callable (functions, classes used with `new`) and property
+ * access (enum-like namespaces, e.g. `ProgressLocation.SourceControl`).
+ * Both resolve to another such proxy.
+ */
+function buildVscodeStubSource(names) {
+    return [...names].map(name => {
+        const decl = name === "default" ? "export default" : `export const ${name} =`;
+        return `${decl} new Proxy(function () {}, { get: () => new Proxy(function () {}, {}) });`;
+    }).join("\n");
+}
+
+const entryPoints = process.argv.slice(2);
+if (entryPoints.length === 0) {
+    console.error("usage: load-check.mjs <entry-point.js>...");
+    process.exit(1);
+}
+
+const vscodeNames = new Set();
+for (const entryPoint of entryPoints) {
+    for (const name of await collectVscodeNames(path.dirname(entryPoint))) {
+        vscodeNames.add(name);
+    }
+}
+console.error("Stubbing vscode names:", [...vscodeNames].sort().join(", "));
+
+const VSCODE_STUB_URL = "vscode-stub:vscode";
+const stubSource = buildVscodeStubSource(vscodeNames);
+
+registerHooks({
+    resolve(specifier, context, nextResolve) {
+        if (specifier === "vscode") return { url: VSCODE_STUB_URL, shortCircuit: true };
+        return nextResolve(specifier, context);
+    },
+    load(url, context, nextLoad) {
+        if (url === VSCODE_STUB_URL) {
+            return { format: "module", source: stubSource, shortCircuit: true };
+        }
+        return nextLoad(url, context);
+    },
+});
+
+// Entry points may run CLI-style top-level logic that calls `process.exit()` when invoked without
+// their expected argv/env (e.g. `askpass-main.js` checks `process.argv.length` and bails). That is not
+// a load failure, so `process.exit` is neutralised for the duration of the import.
+// Only a thrown/rejected error (parse or instantiation failure) fails the check.
+const realExit = process.exit;
+process.exit = () => {};
+let failed = false;
+try {
+    for (const entryPoint of entryPoints) {
+        try {
+            await import(pathToFileURL(entryPoint).href);
+            console.log("OK:", entryPoint);
+        } catch (err) {
+            failed = true;
+            console.error("FAILED to load", entryPoint);
+            console.error(err);
+        }
+    }
+} finally {
+    process.exit = realExit;
+}
+if (failed) process.exit(1);

--- a/integration_tests/electron_host/run-load-check.sh
+++ b/integration_tests/electron_host/run-load-check.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Runs a JS runtime binary (Electron in ELECTRON_RUN_AS_NODE mode, or plain
+# Node as a control) against load-check.mjs. See BUILD.bazel.
+set -euo pipefail
+
+runtime="$1"
+shift
+exec "$runtime" "$@"

--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,10 @@
     "$schema": "https://unpkg.com/knip@6/schema.json",
     "workspaces": {
         ".": {
+            "entry": [
+                "integration_tests/electron_host/check-electron-pin.mjs",
+                "integration_tests/electron_host/load-check.mjs"
+            ],
             "ignoreDependencies": [
                 "@typescript/native",
                 "renovate"


### PR DESCRIPTION
Regression test to prevent re-occurrence of issues such as `import source` not being supported under Electron.