### PR TITLE
Remove `temporal-polyfill`

### DIFF
--- a/extension/BUILD.bazel
+++ b/extension/BUILD.bazel
@@ -27,7 +27,6 @@ ts_project(
         ":node_modules/just-debounce",
         ":node_modules/monolithic-git-interop",
         ":node_modules/onetime",
-        ":node_modules/temporal-polyfill",
         ":node_modules/throat",
         ":node_modules/vscode-diff",
         ":node_modules/watcher",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,6 @@
     "private": true,
     "type": "module",
     "dependencies": {
-        "temporal-polyfill": "catalog:",
         "@vscode/extension-telemetry": "^1.5.2",
         "ignore": "^7.0.6",
         "just-debounce": "^1.1.0",

--- a/extension/src/git.ts
+++ b/extension/src/git.ts
@@ -21,7 +21,6 @@ import { EventEmitter } from "node:events";
 import { promises as fs } from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { fromFields } from "temporal-polyfill/fns/Duration";
 import type { OutputChannel, Progress } from "vscode";
 import {
     type Branch,
@@ -521,8 +520,9 @@ export class Repository {
 
         const result = await exec(child);
 
-        const duration = fromFields({ milliseconds: Date.now() - start });
-        const durationStr = new Intl.DurationFormat("en", { style: "narrow" }).format(duration);
+        const durationStr = new Intl.DurationFormat("en", { style: "narrow" }).format({
+            milliseconds: Date.now() - start,
+        });
 
         if (isErr(result)) {
             this.git.log(`${invocId} < ERROR (PID = ${pid}; Duration = ${durationStr})`);

--- a/extension/src/git/find.ts
+++ b/extension/src/git/find.ts
@@ -2,7 +2,6 @@ import { fromEnvironment, fromPath, type GitContext, type PersistentCLIContext }
 import { createServices } from "monolithic-git-interop/services/nodejs";
 import { isErr, isOk, unwrap } from "monolithic-git-interop/util/result";
 import * as path from "node:path";
-import { fromFields } from "temporal-polyfill/fns/Duration";
 import type { OutputChannel } from "vscode";
 import { snoopOnStream, SnoopStream } from "../util/snoop-stream.js";
 
@@ -70,8 +69,9 @@ export async function findGit(outputChannel: OutputChannel, hints: string[]): Pr
                     args,
                 );
 
-                const duration = fromFields({ milliseconds: Date.now() - start });
-                const durationStr = new Intl.DurationFormat("en", { style: "narrow" }).format(duration);
+                const durationStr = new Intl.DurationFormat("en", { style: "narrow" }).format({
+                    milliseconds: Date.now() - start,
+                });
 
                 // Log result
                 if (isErr(result)) {

--- a/extension/src/git/git-class/internal-exec.ts
+++ b/extension/src/git/git-class/internal-exec.ts
@@ -1,5 +1,4 @@
 import { isErr, unwrap } from "monolithic-git-interop/util/result";
-import { fromFields } from "temporal-polyfill/fns/Duration";
 import { getGitErrorCode, GitError } from "../error.js";
 import { exec, type IExecutionResult } from "../exec.js";
 import type { SpawnOptions } from "../SpawnOptions.js";
@@ -34,8 +33,7 @@ export async function internalExec(
 
     const execResult = await exec(child, options.abortSignal);
 
-    const duration = fromFields({ milliseconds: Date.now() - start });
-    const durationStr = new Intl.DurationFormat("en", { style: "narrow" }).format(duration);
+    const durationStr = new Intl.DurationFormat("en", { style: "narrow" }).format({ milliseconds: Date.now() - start });
 
     if (isErr(execResult)) {
         log(`${invocId} < ERROR (PID = ${pid}; Duration = ${durationStr})`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,6 @@ catalogs:
     get-stream:
       specifier: ^9.0.1
       version: 9.0.1
-    temporal-polyfill:
-      specifier: ^1.0.1
-      version: 1.0.1
   vscode:
     '@types/node':
       specifier: ^24.13.3
@@ -103,9 +100,6 @@ importers:
       onetime:
         specifier: ^8.0.0
         version: 8.0.0
-      temporal-polyfill:
-        specifier: 'catalog:'
-        version: 1.0.1
       throat:
         specifier: ^6.0.2
         version: 6.0.2
@@ -3770,15 +3764,6 @@ packages:
   temp-dir@3.0.0:
     resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
     engines: {node: '>=14.16'}
-
-  temporal-polyfill@1.0.1:
-    resolution: {integrity: sha512-N2SoI9olnW7BUsU8RosDphZQl9s+WJ8O7PoJMFCr/e5/1rFkVI4GNOWaSeySG+UoP04foPYsnLWbJmbXOiShZg==}
-
-  temporal-spec@1.0.0:
-    resolution: {integrity: sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==}
-
-  temporal-utils@1.0.1:
-    resolution: {integrity: sha512-HAixuesxFQIUaQk3ptX2jhfO/FsOkgVkDDMawvp6n/fkB1q6BKfs3lURw9I+pK/2e2e/q/vrLrxmeqauBoyGMQ==}
 
   terminal-columns@2.0.0:
     resolution: {integrity: sha512-6IByuUjyNZJXUtwDNm+OIe62zgwwaRbH+WMNTcx05O2G5V9WhvluAAHJY8OvUdwmzMPpqAD/7EUpGdI6ae1aiQ==}
@@ -8507,15 +8492,6 @@ snapshots:
       yallist: 5.0.0
 
   temp-dir@3.0.0: {}
-
-  temporal-polyfill@1.0.1:
-    dependencies:
-      temporal-spec: 1.0.0
-      temporal-utils: 1.0.1
-
-  temporal-spec@1.0.0: {}
-
-  temporal-utils@1.0.1: {}
 
   terminal-columns@2.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,6 @@ catalog:
   ava: ^8.0.1
   cleye: ^2.6.0
   get-stream: ^9.0.1
-  temporal-polyfill: ^1.0.1
 
 catalogs:
   vscode:


### PR DESCRIPTION
Turns out we could just use an object literal the whole time.