### PR TITLE
Enable path mapping in builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,32 @@
 common --symlink_prefix=.bazel/
 common --lockfile_mode=error
 
+# Path mapping strips the configuration segment (`bazel-out/k8-fastbuild/bin`) from action
+# command lines, so actions that differ only by configuration share cache entries. It only
+# pays off with a disk or remote cache, and needs sandboxed (or remote) execution.
+# https://github.com/bazelbuild/bazel/discussions/22658
+common --disk_cache=~/.cache/bazel-disk
+common --experimental_disk_cache_gc_max_size=20G
+build --experimental_output_paths=strip
+
+# Native C/C++ actions support path mapping but require an explicit opt-in. Starlark
+# actions have to opt in too; `@aspect_rules_js` (NpmPackageExtract) and `@llvm` already
+# do so themselves. Do not add a mnemonic here without first checking that the action
+# builds its command line from `Args` holding `File` objects — an action that bakes a
+# path into an env var, a generated manifest or a plain string will break under mapping.
+build --modify_execution_info=CppCompile=+supports-path-mapping
+build --modify_execution_info=CppModuleMap=+supports-path-mapping
+build --modify_execution_info=CppArchive=+supports-path-mapping
+
+# `@rules_rust` opts every Rust action in unconditionally, but `@llvm`'s C/C++ toolchain
+# hands back link flags as pre-joined strings (`-Lbazel-out/k8-opt-exec/...`,
+# `-Bbazel-out/...`), which Bazel only rewrites when they come from a `File`. A mapped
+# `Rustc` link action therefore looks for `crt1.o` and `libc` under a path that the
+# sandbox no longer contains. Opting the whole family back out keeps the two consistent;
+# `CargoBuildScriptRun` writes `-L` search paths into param files that `Rustc` reads, so
+# they have to be mapped or unmapped together.
+build --modify_execution_info=^(Rustc|RustcMetadata|CargoBuildScriptRun|ExtractCargoTomlEnvVars|Clippy)$=-supports-path-mapping
+
 common --@aspect_rules_ts//ts:skipLibCheck=honor_tsconfig
 common --@aspect_rules_ts//ts:default_to_tsc_transpiler
 

--- a/build_defs/vsix_package/vsix_package.bzl
+++ b/build_defs/vsix_package/vsix_package.bzl
@@ -28,17 +28,18 @@ def _vsix_package_impl(ctx):
     )
 
     out = ctx.actions.declare_file("%s.vsix" % ctx.label.name)
-    arguments = [
-        "--in-dir",
-        inputs_dir.path,
-        "--out-file",
-        out.path,
-    ]
+
+    # Built from `File` objects rather than `.path` strings so that the command line
+    # survives `--experimental_output_paths=strip`. `expand_directories` has to be off,
+    # otherwise `inputs_dir` is replaced by the files it contains.
+    arguments = ctx.actions.args()
+    arguments.add_all(["--in-dir", inputs_dir], expand_directories = False)
+    arguments.add_all(["--out-file", out])
     if ctx.attr.verbose:
-        arguments.append("--verbose")
+        arguments.add("--verbose")
     ctx.actions.run(
         executable = ctx.executable._packaging_tool,
-        arguments = arguments,
+        arguments = [arguments],
         env = {
             "BAZEL_BINDIR": ctx.bin_dir.path,
         },


### PR DESCRIPTION
Not expecting _huge_ wins here, but it'll help drive forward [bazelbuild/bazel#6526](https://redirect.github.com/bazelbuild/bazel/issues/6526) (path mapping discussion: https://github.com/bazelbuild/bazel/discussions/22658).

`@rules_rust` opted out citing bugs in `@llvm` (embedding paths with configuration names present).